### PR TITLE
fix(api/site): Make rdata consistent between server and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ ZoneForge simplifies the *management* of RFC1035/BIND-style DNS zone files by pr
 - Deployment flexibility for various environments.
 
 ## Table of Contents
-- [About](#About)
-- [Features](#Features)
-- [Usage](#Usage)
-- [Resources](#Resources)
-- [Credits](#Credits)
+- [About](#about)
+- [Configuration](#configuration)
+- [API Features](#api-features)
+  - [Zones](#zones)
+  - [Records](#records)
+- [Roadmap](#roadmap)
+- [Resources](#resources)
+  - [Zone Files](#zone-files)
+  - [Record Types](#record-types)
+  - [RFCs](#rfcs)
+  - [Migrating Existing DNS to a Zone File](#migrating-existing-dns-to-a-zone-file)
+- [Credits](#credits)
 
 # Configuration
 
@@ -34,6 +41,8 @@ Environment variables are available to configure the application.
 | DEFAULT_ZONE_TTL | 86400 | The default TTL for new zones. |
 
 # API Features
+
+Note that deprecated fields are not supported by ZoneForge.
 
 ## Zones
 
@@ -187,6 +196,10 @@ For each domain that a given DNS server is authorative for:
 
 5. The file `db.example.com` should now contain a RFC1035-compatible zone file.
 
+
+# Contributing
+
+Contributions are welcome. Please follow [conventional commit syntax](https://www.conventionalcommits.org/en/v1.0.0/).
 
 # Credits
 

--- a/app.py
+++ b/app.py
@@ -33,22 +33,24 @@ def home():
 
 @app.route("/zone/<string:zone_name>", methods=['GET'])
 def zone(zone_name):
+    zone = zf_api.get_zones(zone_name=zone_name)[0].to_response()
     zf_record = zf_api.RecordResource()
     records = zf_record.get(zone_name=zone_name)
-    soa = zf_record.get(zone_name=zone_name, record_type='SOA')[0]
     current_zone_data = {
         "name": zone_name,
-        "soa_ttl": soa["ttl"],
-        "admin_email": soa["data"]["rname"],
-        "refresh": soa["data"]["refresh"],
-        "retry": soa["data"]["retry"],
-        "expire": soa["data"]["expire"],
-        "minimum": soa["data"]["minimum"],
-        "primary_ns": soa["data"]["mname"],
-
+        "soa_ttl": zone['soa']['ttl'],
+        "admin_email": zone['soa']['data']['rname'],
+        "refresh": zone['soa']['data']['refresh'],
+        "retry": zone['soa']['data']['retry'],
+        "expire": zone['soa']['data']['expire'],
+        "minimum": zone['soa']['data']['minimum'],
+        "primary_ns": zone['soa']['data']['mname'],
     }
-    return render_template('zone.html.j2', zone=zone_name, soa=soa, records=records, modal=ZONE_EDIT, modal_api='/api/zone', modal_default_values=current_zone_data)
+    record_types = zf_api.RecordTypeResource()
+    record_types = record_types.get()
+    return render_template('zone.html.j2', zone=zone, records=records, modal=ZONE_EDIT, modal_api='/api/zone', modal_default_values=current_zone_data, record_types=record_types)
 
 api.add_resource(zf_api.StatusResource, '/status')
 api.add_resource(zf_api.ZoneResource, '/zone', '/zone/<string:zone_name>')
 api.add_resource(zf_api.RecordResource, '/zone/<string:zone_name>/record', '/zone/<string:zone_name>/record/<string:record_name>')
+api.add_resource(zf_api.RecordTypeResource, '/types/recordtype', '/types/recordtype/<string:record_type>')

--- a/static/css/zone.css
+++ b/static/css/zone.css
@@ -140,28 +140,7 @@ td:nth-child(7) { width: 17%; min-width: 160px; } /* Actions */
 
 .data-row {
     margin: 0;
-}
-
-.add-data-row {
-    padding: 2px 8px;
-    background-color: #4CAF50;
-    color: white;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 1.2rem;
-    line-height: 1;
-}
-
-.remove-data-row {
-    padding: 2px 8px;
-    background-color: #f44336;
-    color: white;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 1.2rem;
-    line-height: 1;
+    width: 100%;
 }
 
 .manager {

--- a/templates/zone.html.j2
+++ b/templates/zone.html.j2
@@ -2,19 +2,19 @@
 {% block content %}
     <div class="manager">
         <div class="header-row">
-            <h3>Zone: {{zone}}</h3>
+            <h3>Zone: {{zone.name}}</h3>
             <div class="soa-details">
                 <div class="soa-details-row">
-                    <p>Primary NS: {{soa.data.mname}}</p>
-                    <p>Email: {{soa.data.rname}}</p>
-                    <p>Default TTL: {{soa.ttl}}</p>
-                    <p>Serial: {{soa.data.serial}}</p>
+                    <p>Primary NS: {{zone.soa.data.mname}}</p>
+                    <p>Email: {{zone.soa.data.rname}}</p>
+                    <p>Default TTL: {{zone.soa.ttl}}</p>
+                    <p>Serial: {{zone.soa.data.serial}}</p>
                 </div>
                 <div class="soa-details-row">
-                    <p>Refresh: {{soa.data.refresh}}</p>
-                    <p>Retry: {{soa.data.retry}}</p>
-                    <p>Expire: {{soa.data.expire}}</p>
-                    <p>Minimum: {{soa.data.minimum}}</p>
+                    <p>Refresh: {{zone.soa.data.refresh}}</p>
+                    <p>Retry: {{zone.soa.data.retry}}</p>
+                    <p>Expire: {{zone.soa.data.expire}}</p>
+                    <p>Minimum: {{zone.soa.data.minimum}}</p>
                 </div>
             </div>
             <div class="zone-options">
@@ -38,7 +38,7 @@
                 </thead>
                 <tbody>
                     {% for record in records %}
-                    {% set record_url_path = url_for("record_resource", **{"record_name": record.name, "zone_name": zone}) %}
+                    {% set record_url_path = url_for("record_resource", **{"record_name": record.name, "zone_name": zone.name}) %}
                     <tr data-record-name="{{ record.name }}" data-url="{{ record_url_path }}">
                         <td><input type="checkbox"></td>
                         <td class="editable" data-field="name">{{ record.name }}</td>
@@ -49,7 +49,7 @@
                                 <div class="data-rows">
                                     {% for key, value in record.data.items() %}
                                     <div class="data-entry">
-                                        <p class="data-row-label">{{ key[0]|upper}}{{key[1:] }}:</p>
+                                        <p class="data-row-label">{{ key.split('_')|map('capitalize')|join(' ') }}:</p>
                                         <p class="data-row editable" data-field="data">{{ value }}</p>
                                     </div>
                                     {% endfor %}
@@ -68,14 +68,19 @@
                     </tr>
                     {% endfor %}
                     <!-- New Record Row -->
-                    {% set new_record_url = url_for("record_resource", **{"record_name": "_new", "zone_name": zone}) %}
+                    {% set new_record_url = url_for("record_resource", **{"record_name": "_new", "zone_name": zone.name}) %}
                     <tr class="new-record" data-url="{{ new_record_url }}">
                         <td><input type="checkbox" disabled></td>
                         <td class="editable" data-field="name">
                             <input type="text" placeholder="name">
                         </td>
                         <td class="editable" data-field="type">
-                            <input type="text" placeholder="type">
+                            <select>
+                                <option selected disabled value="">Select Record Type</option>
+                                {% for record_type_name, record_type_data in record_types.items() %}
+                                    <option value="{{ record_type_name }}">{{ record_type_name }}</option>
+                                {% endfor %}
+                            </select>
                         </td>
                         <td class="editable" data-field="ttl">
                             <input type="text" placeholder="ttl">
@@ -87,7 +92,6 @@
                                     <p class="data-row editable" data-field="data">
                                         <input type="text" placeholder="data">
                                     </p>
-                                    <button type="button" class="add-data-row">+</button>
                                 </div>
                             </div>
                         </td>


### PR DESCRIPTION
Ensure rdata is consistently handled between requests and response bodies. This means dynamically handling each type of rdata and ensuring it gets properly returned in JSON, and displayed nicely on the site

Also includes changing to a record-type dropdown in the site when editing/creating records, and auto-labeling/creating the required data fields for that record type.


Closes #44 