### PR TITLE
fix(image): Ensure gunicorn can start app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ ENV GUNICORN_WORKERS=4
 ENV GUNICORN_CMD_ARGS="--bind 0.0.0.0:${PORT} --workers ${GUNICORN_WORKERS}"
 ENV PATH="${PATH}:/home/appuser/.local/bin"
 EXPOSE ${PORT}/tcp
-CMD ["gunicorn", "app:app"]
+CMD ["gunicorn", "app:production"]

--- a/app.py
+++ b/app.py
@@ -76,4 +76,7 @@ def create_app():
     return app
 
 if __name__=="__main__":
-    create_app()
+    dev = create_app()
+    dev.run()
+else:
+    production = create_app()


### PR DESCRIPTION
getting an exception in image `0.0.2-build001`:

```
Failed to find attribute 'app' in 'app'.
```

This is due to switching to the application factory pattern in the refactor:

https://docs.gunicorn.org/en/stable/run.html#gunicorn