### PR TITLE
fix: escape "strings" slot in records

### DIFF
--- a/tests/unit/core/test_zf.py
+++ b/tests/unit/core/test_zf.py
@@ -396,6 +396,45 @@ def test_zf_delete_a_record(app_with_single_zone, zfzone_common_data):
             assert True
 
 
+def test_zf_delete_txt_record(app_with_single_zone, zfzone_common_data):
+    zone_name = str(zfzone_common_data.origin)
+    record_name = "@"
+    record_type = "TXT"
+    record_ttl = "86400"
+    record_data = {"strings": "This domain name is reserved for use in documentation"}
+    record_index = 0
+
+    with app_with_single_zone.app_context():
+        existing_records = get_records(
+            zone_name=zone_name, record_name=record_name, record_type=record_type
+        )
+    assert len(existing_records) == 1
+    # pylint: disable=protected-access
+    assert record_data["strings"] == dns.rdata._escapify(
+        existing_records[0][0].strings[0]
+    )
+    # pylint: enable=protected-access
+
+    with app_with_single_zone.app_context():
+        _ = delete_record(
+            record_name=record_name,
+            record_type=record_type,
+            record_data=record_data,
+            record_ttl=record_ttl,
+            record_index=record_index,
+            zone_name=zone_name,
+        )
+
+    with app_with_single_zone.app_context():
+        try:
+            _ = get_records(
+                zone_name=zone_name, record_name=record_name, record_type=record_type
+            )
+            assert False
+        except NotFound:
+            assert True
+
+
 def test_zf_delete_single_record_under_rrset(app_with_single_zone, zfzone_common_data):
     zone_name = str(zfzone_common_data.origin)
     record_name = "@"

--- a/zoneforge/core/__init__.py
+++ b/zoneforge/core/__init__.py
@@ -382,9 +382,8 @@ def record_to_response(records: list[dns.rrset.RRset]) -> dict:
             for slot in record_slots:
                 property_value = getattr(rdata, slot)
                 # perform any necessary transformations
-                if (
-                    property_value is not None
-                ):  # needs to be explicitly checked for None since dns.name.Name for a root record is evaluated to False (len=0)
+                # needs to be explicitly checked for None since dns.name.Name for a root record is evaluated to False (len=0)
+                if property_value is not None:
                     if slot == "strings":
                         txt = ""
                         prefix = ""
@@ -435,7 +434,10 @@ def request_to_rdata(
     # construct rdata class values from string in the proper order. We could pass these to a constructor as kwargs, but we don't currently have client side rdata slot typing
     rdata_str = ""
     for rdata_slot in get_rdata_class_slots(record_type):
-        rdata_str += f"{record_data[rdata_slot]} "
+        slot_data = record_data[rdata_slot]
+        if rdata_slot == "strings":
+            slot_data = f'"{slot_data}"'
+        rdata_str += f"{slot_data} "
     rdata = dns.rdata.from_text(rdclass=record_class, rdtype=record_type, tok=rdata_str)
 
     if record_comment:


### PR DESCRIPTION
Fixes an issue where TXT (and possibly other) records couldn't be deleted, and updates caused the zonefile to be modified in a weird way.

Also adds a test for this scenario.

Closes #85